### PR TITLE
ttc-connectors-processing to 1.0.6

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,15 +1,18 @@
 dependencies:
-- name: exposecontroller
-  version: 2.3.58
+- alias: expose
+  name: exposecontroller
   repository: http://chartmuseum.build.cd.jenkins-x.io
-  alias: expose
-- name: exposecontroller
   version: 2.3.58
+- alias: cleanup
+  name: exposecontroller
   repository: http://chartmuseum.build.cd.jenkins-x.io
-  alias: cleanup
+  version: 2.3.58
 - name: rabbitmq
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.8.0
 - name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.11.0
+- name: ttc-connectors-processing
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.6


### PR DESCRIPTION
Promote ttc-connectors-processing to version 1.0.6