### PR TITLE
ttc-connectors-ranking to 1.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -16,3 +16,6 @@ dependencies:
 - name: ttc-connectors-processing
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.6
+- name: ttc-connectors-ranking
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.7


### PR DESCRIPTION
Promote ttc-connectors-ranking to version 1.0.7