### PR TITLE
ttc-connectors-reward to 1.0.7

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -19,3 +19,6 @@ dependencies:
 - name: ttc-connectors-ranking
   repository: http://jenkins-x-chartmuseum:8080
   version: 1.0.7
+- name: ttc-connectors-reward
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 1.0.7


### PR DESCRIPTION
Promote ttc-connectors-reward to version 1.0.7